### PR TITLE
Pin GitHub Actions to digests

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
       - name: Check if PR should be auto-merged
-        uses: ahmadnassri/action-dependabot-auto-merge@v2
+        uses: ahmadnassri/action-dependabot-auto-merge@45fc124d949b19b6b8bf6645b6c9d55f4f9ac61a # v2
         with:
           github-token: ${{ secrets.AUTO_MERGE_TOKEN }}
           command: squash and merge

--- a/.github/workflows/new-issue.yml
+++ b/.github/workflows/new-issue.yml
@@ -14,12 +14,12 @@ jobs:
     steps:
       - name: Setup node
         id: setup_node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4
         with:
           node-version: 20
       - name: Get package name
         id: get_package_name
-        uses: ASzc/change-string-case-action@v6
+        uses: ASzc/change-string-case-action@d0603cd0a7dd490be678164909f65c7737470a7f # v6
         with:
           string: ${{ github.event.repository.name }}
       - name: Get NPM version
@@ -28,7 +28,7 @@ jobs:
       - name: Create comment
         id: create_comment_ok
         if: ${{ contains(github.event.issue.body, steps.get_npm_version.outputs.LATEST_VERSION) }}
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |
@@ -41,7 +41,7 @@ jobs:
       - name: Create comment (beta version)
         id: create_comment_version
         if: ${{ !contains(github.event.issue.body, steps.get_npm_version.outputs.LATEST_VERSION) }}
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
         with:
           issue-number: ${{ github.event.issue.number }}
           body: |

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: ioBroker/testing-action-check@v1
+      - uses: ioBroker/testing-action-check@52f69d4bbaf791d8ffdc79a2d81602c21b42c62f # v1
         with:
           node-version: '20.x'
           lint: true
@@ -42,7 +42,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: ioBroker/testing-action-adapter@v1
+      - uses: ioBroker/testing-action-adapter@6c665d40fd4300c3a67769cc22877fa5243a327f # v1
         with:
           node-version: ${{ matrix.node-version }}
           os: ${{ matrix.os }}
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: ioBroker/testing-action-deploy@v1
+      - uses: ioBroker/testing-action-deploy@fe46ae1f940278ce28ae5a2d1356a31f79454827 # v1
         with:
           node-version: '20.x'
           npm-token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Hey there 👋

I work on an open source security project ([Frizbee](https://github.com/stacklok/frizbee)) that can automatically pin GitHub Actions to digests (instead of floating tags). 

The Frizbee team is trying to spread the word to open source maintainers about the need for this, because pinning your actions to commit hashes is the *only* way to get an immutable pointer to a specific revision. If an action's source code repo is compromised by a malicious actor, you'll still be referencing a known-good version and your project won't be at risk. 

The following PR pins your actions to their commit hash and it was done using the [frizbee](https://github.com/stacklok/frizbee) CLI. Frizbee also appends a comment so you can easily see which version this digest corresponds to.

Note that Dependabot supports updating pinned actions and will continue to update them.

If you liked it and also want to keep this consistent in case you add more unpinned actions in future, there's a [frizbee-action](https://github.com/stacklok/frizbee-action) which you can use to help automate this.

Thanks!
